### PR TITLE
Don't clobber BUILD_SHARED_LIBS

### DIFF
--- a/src/lib_proj.cmake
+++ b/src/lib_proj.cmake
@@ -4,21 +4,6 @@ message(STATUS "Configuring proj library:")
 ### SWITCH BETWEEN STATIC OR SHARED LIBRARY###
 ##############################################
 
-# Support older option, to be removed by PROJ 8.0
-if(DEFINED BUILD_LIBPROJ_SHARED)
-  message(DEPRECATION
-    "BUILD_LIBPROJ_SHARED has been replaced with BUILD_SHARED_LIBS")
-  set(BUILD_SHARED_LIBS ${BUILD_LIBPROJ_SHARED})
-endif()
-
-# default config is shared, except static on Windows
-set(BUILD_SHARED_LIBS_DEFAULT ON)
-if(WIN32)
-  set(BUILD_SHARED_LIBS_DEFAULT OFF)
-endif()
-option(BUILD_SHARED_LIBS
-  "Build PROJ library shared." ${BUILD_SHARED_LIBS_DEFAULT})
-
 option(USE_THREAD "Build libproj with thread/mutex support " ON)
 if(NOT USE_THREAD)
   add_definitions(-DMUTEX_stub)


### PR DESCRIPTION
`BUILD_SHARED_LIBS` is a cmake option that control whether libraries are built as static or shared objects. Like all cmake variables it evaluates to false when not explicitly specified, in this case defaults to building static libraries unless `-DBUILD_SHARED_LIBS=ON` is given at configure time.

PROJ is overriding this default value so that unless explicitly specified it will build shared libraries rather than static. This is causing some problems elsewhere such as in PFWP. Generally speaking projects shouldn't be setting this variable to anything at all since it is considered to be a site option rather than anything specific to a target.